### PR TITLE
Added check for empty string to read statements

### DIFF
--- a/scripts/bash_cafe.sh
+++ b/scripts/bash_cafe.sh
@@ -47,7 +47,7 @@ clear
 
 #main loop
 while true; do
-clear
+    clear
     #output the day and weather
     center " Day $day_num "
     sleep 1
@@ -64,6 +64,8 @@ clear
         read -p "How many coffees do you wish make? >>> " coffee_cnt
         if (( coffee_cnt*expense > cash)) || [ ! -z "${coffee_cnt##[0-9]*}" ]; then
             echo "You cannot do that!"
+	elif [ -z "$coffee_cnt" ]; then
+	    :
         else
             break
         fi
@@ -72,6 +74,8 @@ clear
         read -p "How much do you wish to charge per coffee? >>> " coffee_cost
         if [ ! -z "${coffee_cost##[0-9]*}" ]; then
             echo "You cannot do that!"
+	elif [ -z "$coffee_cnt" ]; then
+	    :
         else
             break  
         fi


### PR DESCRIPTION
The read statements will now ignore an empty
string, and go back to the top of the loop.
Previously they would hit the else statement
and break out of the loop.

This should fix issue #6.